### PR TITLE
Adjust tile layout into three rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ A jelenlegi weboldal [sup.hu/kov](https://www.sup.hu/kov) ami design tekintetéb
 - A desig lényege a Microsoft által régebben favorizált "csempés" felület.  
   - Legyen fejléc és logo a régihez hasonló módon, csak szebben.  
   - Legyen lábléc a szokások copyright-nak és néhány linknek a fő weboldalra és a Facebook oldalra.  
-  - A középső részen lesznek a csempék, két sorban. Az első sor (nagyobb méretben) a négy legfontosabb modul letöltési hivatkozás (SUP, Raktár, Mérleg, TIP)  
-  a második sor kisebb betűkkel a további modulok (SUP Xls.NET, DbConnector, DbConnector API, QsFdbBackupService)  
-  - Harmadik sorban az egyéb kiegészítő szoftverek (RustDesk, Firebird SQL, WebUpdate)
+  - A középső részen három sorban rendeződnek a csempék. Az első két sorban nagyobb, dupla szélességű csempéken jelenik meg a négy legfontosabb modul (SUP, Raktár, Mérleg, TIP). A harmadik sorban kisebb csempéken láthatók a további modulok és kiegészítő szoftverek (SUP Xls.NET, DbConnector, DbConnector API, QsFdbBackupService, RustDesk, Firebird SQL, WebUpdate).
 
 - A csempék tartalma a fix szöveg mellet a PHP kóddal kiolvasott adatokat tartalmazza. Pontosabban a csempe szöveg csak a modul/szoftver nevét verzió kiadási dátumot.  
 

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <h1>SUP követés letöltések</h1>
 </header>
 <main>
-    <div class="grid">
+    <div class="grid grid-large">
         <div class="tile" style="--tile-color:#0078d7" data-name="SUP" data-version="16.11.9341.41126" data-date="2025.07.29. 11:27:46" data-size="N/A" data-file="SUP_Upd_Setup.exe" data-href="RegiForraskod/FileS/SUP_Upd_Setup.exe">
             <img src="RegiForraskod/kepek/sup.jpg" alt="SUP">
             <span class="name">SUP</span>
@@ -20,6 +20,8 @@
             <span class="version">v16.11.9341.41126</span>
             <a class="download-btn" href="RegiForraskod/FileS/SUP_Upd_Setup.exe">Letöltés</a>
         </div>
+    </div>
+    <div class="grid grid-large">
         <div class="tile" style="--tile-color:#008272" data-name="Raktár" data-version="16.11.9335.58734" data-date="2025.07.22. 16:20:54" data-size="N/A" data-file="RA_Upd_Setup.exe" data-href="RegiForraskod/FileS/RA_Upd_Setup.exe">
             <img src="RegiForraskod/kepek/raktar.jpg" alt="Raktár">
             <span class="name">Raktár</span>
@@ -41,6 +43,8 @@
             <span class="version">v16.11.9335.38874</span>
             <a class="download-btn" href="RegiForraskod/FileS/TIP_Upd_Setup.exe">Letöltés</a>
         </div>
+    </div>
+    <div class="grid grid-small">
         <div class="tile" style="--tile-color:#1b6ac6" data-name="SUP Xls.NET" data-version="16.10" data-date="2024.11.22. 10:50" data-size="N/A" data-file="SUP_XLS_NET_Setup.exe" data-href="RegiForraskod/FileS/SUP_XLS_NET_Setup.exe">
             <img src="RegiForraskod/kepek/xls.jpg" alt="XLS">
             <span class="name">SUP Xls.NET</span>

--- a/index.php
+++ b/index.php
@@ -42,6 +42,12 @@ $modules = [
     'FIREBIRD' => ['name' => 'Firebird SQL', 'desc' => 'Firebird adatbáziskezelő', 'icon' => 'firebird.jpg', 'color' => '#ffb900'],
     'WEBUPDATE' => ['name' => 'WebUpdate', 'desc' => 'Internetes frissítés', 'icon' => 'webupdate.jpg', 'color' => '#2166b5']
 ];
+
+$rows = [
+    'large1' => ['SUP'],
+    'large2' => ['RAKTAR', 'MERLEG', 'TIP'],
+    'small'  => ['XLS', 'DBCONNECTOR', 'DBCONNECTORAPI', 'QSBACKUPFDBSERVICE', 'RUSTDESK', 'FIREBIRD', 'WEBUPDATE']
+];
 ?>
 <!DOCTYPE html>
 <html lang="hu">
@@ -57,8 +63,30 @@ $modules = [
     <h1>SUP követés letöltések</h1>
 </header>
 <main>
-    <div class="grid">
-        <?php foreach($modules as $code => $info): list($v,$d,$s)=get_ver_info($code); $file = module_files($code); ?>
+    <div class="grid grid-large">
+        <?php foreach($rows['large1'] as $code): $info = $modules[$code]; list($v,$d,$s)=get_ver_info($code); $file = module_files($code); ?>
+        <div class="tile" style="--tile-color:<?php echo $info['color']; ?>" data-name="<?php echo $info['name']; ?>" data-version="<?php echo $v; ?>" data-date="<?php echo $d; ?>" data-size="<?php echo $s; ?>" data-file="<?php echo $file; ?>" data-href="RegiForraskod/FileS/<?php echo $file; ?>">
+            <img src="RegiForraskod/kepek/<?php echo $info['icon']; ?>" alt="<?php echo $info['name']; ?>">
+            <span class="name"><?php echo $info['name']; ?></span>
+            <span class="desc"><?php echo $info['desc']; ?></span>
+            <span class="version">v<?php echo $v; ?></span>
+            <a class="download-btn" href="RegiForraskod/FileS/<?php echo $file; ?>">Letöltés</a>
+        </div>
+        <?php endforeach; ?>
+    </div>
+    <div class="grid grid-large">
+        <?php foreach($rows['large2'] as $code): $info = $modules[$code]; list($v,$d,$s)=get_ver_info($code); $file = module_files($code); ?>
+        <div class="tile" style="--tile-color:<?php echo $info['color']; ?>" data-name="<?php echo $info['name']; ?>" data-version="<?php echo $v; ?>" data-date="<?php echo $d; ?>" data-size="<?php echo $s; ?>" data-file="<?php echo $file; ?>" data-href="RegiForraskod/FileS/<?php echo $file; ?>">
+            <img src="RegiForraskod/kepek/<?php echo $info['icon']; ?>" alt="<?php echo $info['name']; ?>">
+            <span class="name"><?php echo $info['name']; ?></span>
+            <span class="desc"><?php echo $info['desc']; ?></span>
+            <span class="version">v<?php echo $v; ?></span>
+            <a class="download-btn" href="RegiForraskod/FileS/<?php echo $file; ?>">Letöltés</a>
+        </div>
+        <?php endforeach; ?>
+    </div>
+    <div class="grid grid-small">
+        <?php foreach($rows['small'] as $code): $info = $modules[$code]; list($v,$d,$s)=get_ver_info($code); $file = module_files($code); ?>
         <div class="tile" style="--tile-color:<?php echo $info['color']; ?>" data-name="<?php echo $info['name']; ?>" data-version="<?php echo $v; ?>" data-date="<?php echo $d; ?>" data-size="<?php echo $s; ?>" data-file="<?php echo $file; ?>" data-href="RegiForraskod/FileS/<?php echo $file; ?>">
             <img src="RegiForraskod/kepek/<?php echo $info['icon']; ?>" alt="<?php echo $info['name']; ?>">
             <span class="name"><?php echo $info['name']; ?></span>

--- a/style.css
+++ b/style.css
@@ -37,8 +37,19 @@ main {
 
 .grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     gap: 20px;
+}
+
+.grid-small {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.grid-large {
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+}
+
+.grid + .grid {
+    margin-top: 20px;
 }
 
 .tile {


### PR DESCRIPTION
## Summary
- fix README to explain three-row layout
- set up `grid-large` and `grid-small` classes
- arrange tiles in three fixed rows in both HTML and PHP

## Testing
- `php -l index.php`

------
https://chatgpt.com/codex/tasks/task_e_688b31dafa888323be5abac6e62da24d