### PR TITLE
Restore tile list and widen page

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,25 +20,105 @@
         </div>
     </div>
     <div class="grid">
-        <div class="tile" style="--tile-color:#0078d7" data-name="SUP" data-version="v2.5.1" data-date="2025.07.29" data-size="50MB" data-file="SUP_Upd_Setup.exe" data-href="#">
+        <div class="tile" style="--tile-color:#0078d7" data-name="SUP" data-version="16.11.9341.41126" data-date="2025.07.29. 11:27:46" data-size="N/A" data-file="SUP_Upd_Setup.exe" data-href="RegiForraskod/FileS/SUP_Upd_Setup.exe">
             <img src="RegiForraskod/kepek/sup.jpg" alt="SUP">
             <span class="name">SUP</span>
-            <span class="version">v2.5.1</span>
+            <span class="version">v16.11.9341.41126</span>
             <div class="actions">
-                <a class="btn download-btn" href="#">Letöltés</a>
+                <a class="btn download-btn" href="RegiForraskod/FileS/SUP_Upd_Setup.exe">Letöltés</a>
                 <button class="btn details-btn">Részletek</button>
             </div>
         </div>
-        <div class="tile" style="--tile-color:#008272" data-name="Raktár" data-version="v1.2" data-date="2025.07.22" data-size="30MB" data-file="RA_Upd_Setup.exe" data-href="#">
+        <div class="tile" style="--tile-color:#008272" data-name="Raktár" data-version="16.11.9335.58734" data-date="2025.07.22. 16:20:54" data-size="N/A" data-file="RA_Upd_Setup.exe" data-href="RegiForraskod/FileS/RA_Upd_Setup.exe">
             <img src="RegiForraskod/kepek/raktar.jpg" alt="Raktár">
             <span class="name">Raktár</span>
-            <span class="version">v1.2</span>
+            <span class="version">v16.11.9335.58734</span>
             <div class="actions">
-                <a class="btn download-btn" href="#">Letöltés</a>
+                <a class="btn download-btn" href="RegiForraskod/FileS/RA_Upd_Setup.exe">Letöltés</a>
                 <button class="btn details-btn">Részletek</button>
             </div>
         </div>
-        <!-- További dummy kártyák -->
+        <div class="tile" style="--tile-color:#ff8c00" data-name="Mérleg" data-version="16.11.9341.34614" data-date="2025.07.29. 09:38:26" data-size="N/A" data-file="LM_Upd_Setup.exe" data-href="RegiForraskod/FileS/LM_Upd_Setup.exe">
+            <img src="RegiForraskod/kepek/merleg.jpg" alt="Mérleg">
+            <span class="name">Mérleg</span>
+            <span class="version">v16.11.9341.34614</span>
+            <div class="actions">
+                <a class="btn download-btn" href="RegiForraskod/FileS/LM_Upd_Setup.exe">Letöltés</a>
+                <button class="btn details-btn">Részletek</button>
+            </div>
+        </div>
+        <div class="tile" style="--tile-color:#68217a" data-name="TIP" data-version="16.11.9335.38874" data-date="2025.07.23. 10:50:20" data-size="N/A" data-file="TIP_Upd_Setup.exe" data-href="RegiForraskod/FileS/TIP_Upd_Setup.exe">
+            <img src="RegiForraskod/kepek/tip.jpg" alt="TIP">
+            <span class="name">TIP</span>
+            <span class="version">v16.11.9335.38874</span>
+            <div class="actions">
+                <a class="btn download-btn" href="RegiForraskod/FileS/TIP_Upd_Setup.exe">Letöltés</a>
+                <button class="btn details-btn">Részletek</button>
+            </div>
+        </div>
+        <div class="tile" style="--tile-color:#1b6ac6" data-name="SUP Xls.NET" data-version="16.10" data-date="2024.11.22. 10:50" data-size="N/A" data-file="SUP_XLS_NET_Setup.exe" data-href="RegiForraskod/FileS/SUP_XLS_NET_Setup.exe">
+            <img src="RegiForraskod/kepek/xls.jpg" alt="XLS">
+            <span class="name">SUP Xls.NET</span>
+            <span class="version">v16.10</span>
+            <div class="actions">
+                <a class="btn download-btn" href="RegiForraskod/FileS/SUP_XLS_NET_Setup.exe">Letöltés</a>
+                <button class="btn details-btn">Részletek</button>
+            </div>
+        </div>
+        <div class="tile" style="--tile-color:#00cc6a" data-name="DbConnector" data-version="16.11.9327.60906" data-date="2025.07.14. 16:57:10" data-size="N/A" data-file="DBConnector_Setup.exe" data-href="RegiForraskod/FileS/DBConnector_Setup.exe">
+            <img src="RegiForraskod/kepek/dbconnector.jpg" alt="DbConnector">
+            <span class="name">DbConnector</span>
+            <span class="version">v16.11.9327.60906</span>
+            <div class="actions">
+                <a class="btn download-btn" href="RegiForraskod/FileS/DBConnector_Setup.exe">Letöltés</a>
+                <button class="btn details-btn">Részletek</button>
+            </div>
+        </div>
+        <div class="tile" style="--tile-color:#e81123" data-name="DbConnector API" data-version="3.1.9335" data-date="2025.02.18. 12:27" data-size="N/A" data-file="DbConnectorApi.jar" data-href="RegiForraskod/FileS/DbConnectorApi.jar">
+            <img src="RegiForraskod/kepek/dbconnectorapi.jpg" alt="DbConnector API">
+            <span class="name">DbConnector API</span>
+            <span class="version">v3.1.9335</span>
+            <div class="actions">
+                <a class="btn download-btn" href="RegiForraskod/FileS/DbConnectorApi.jar">Letöltés</a>
+                <button class="btn details-btn">Részletek</button>
+            </div>
+        </div>
+        <div class="tile" style="--tile-color:#0099bc" data-name="QsFdbBackupService" data-version="2.1" data-date="2024.06.05. 09:00" data-size="N/A" data-file="QsBackupFdbService.zip" data-href="RegiForraskod/FileS/QsBackupFdbService.zip">
+            <img src="RegiForraskod/kepek/qsfdb.png" alt="QsFdbBackupService">
+            <span class="name">QsFdbBackupService</span>
+            <span class="version">v2.1</span>
+            <div class="actions">
+                <a class="btn download-btn" href="RegiForraskod/FileS/QsBackupFdbService.zip">Letöltés</a>
+                <button class="btn details-btn">Részletek</button>
+            </div>
+        </div>
+        <div class="tile" style="--tile-color:#da3b01" data-name="RustDesk" data-version="1.2.0" data-date="2023.02.20. 11:38" data-size="N/A" data-file="RustDeskQsoft.exe" data-href="RegiForraskod/FileS/RustDeskQsoft.exe">
+            <img src="RegiForraskod/kepek/tavman.jpg" alt="RustDesk">
+            <span class="name">RustDesk</span>
+            <span class="version">v1.2.0</span>
+            <div class="actions">
+                <a class="btn download-btn" href="RegiForraskod/FileS/RustDeskQsoft.exe">Letöltés</a>
+                <button class="btn details-btn">Részletek</button>
+            </div>
+        </div>
+        <div class="tile" style="--tile-color:#ffb900" data-name="Firebird SQL" data-version="3.0.12" data-date="2024.12.18. 11:00" data-size="N/A" data-file="FB30_QSoft_Setup.exe" data-href="RegiForraskod/FileS/FB30_QSoft_Setup.exe">
+            <img src="RegiForraskod/kepek/firebird.jpg" alt="Firebird">
+            <span class="name">Firebird SQL</span>
+            <span class="version">v3.0.12</span>
+            <div class="actions">
+                <a class="btn download-btn" href="RegiForraskod/FileS/FB30_QSoft_Setup.exe">Letöltés</a>
+                <button class="btn details-btn">Részletek</button>
+            </div>
+        </div>
+        <div class="tile" style="--tile-color:#2166b5" data-name="WebUpdate" data-version="16.6.8851.38885" data-date="2024.03.26. 11:50:14" data-size="N/A" data-file="WebUpdate.exe" data-href="RegiForraskod/FileS/WebUpdate.exe">
+            <img src="RegiForraskod/kepek/webupdate.jpg" alt="WebUpdate">
+            <span class="name">WebUpdate</span>
+            <span class="version">v16.6.8851.38885</span>
+            <div class="actions">
+                <a class="btn download-btn" href="RegiForraskod/FileS/WebUpdate.exe">Letöltés</a>
+                <button class="btn details-btn">Részletek</button>
+            </div>
+        </div>
     </div>
 </main>
 <div id="modal" class="modal">

--- a/style.css
+++ b/style.css
@@ -51,8 +51,8 @@ header h1 {
 }
 
 main {
-    max-width: 1200px;
-    margin: auto;
+    width: 95%;
+    margin: 0 auto;
     padding: 20px;
 }
 


### PR DESCRIPTION
## Summary
- restore all download tiles on the HTML page
- expand main layout width so tiles use more of the screen

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_688b3b945a6483238effdde63494ed4f