### PR TITLE
Ensure grid layout uses four columns on desktop

### DIFF
--- a/style.css
+++ b/style.css
@@ -59,7 +59,13 @@ main {
 .grid {
     display: grid;
     gap: 20px;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+}
+
+@media (min-width: 1000px) {
+    .grid {
+        grid-template-columns: repeat(4, 1fr);
+    }
 }
 
 .tile {


### PR DESCRIPTION
## Summary
- enforce four-column layout for tiles on large screens

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_688b3ec29488832389f38310260bb0fd