### PR TITLE
Modify header and center logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,10 +8,9 @@
 </head>
 <body>
 <header>
-    <img src="RegiForraskod/kepek/suplogo.jpg" alt="SUP logo" class="logo">
-    <h1>SUP követés letöltések</h1>
 </header>
 <main>
+    <img src="RegiForraskod/kepek/suplogo.jpg" alt="SUP logo" class="hero-logo">
     <div class="grid">
         <h2 class="section-title">SUP® Rendszerrel kapcsolatos frissítések letöltése</h2>
         <div class="tile" style="--tile-color:#0078d7" data-name="SUP" data-version="16.11.9341.41126" data-date="2025.07.29. 11:27:46" data-size="N/A" data-file="SUP_Upd_Setup.exe" data-href="RegiForraskod/FileS/SUP_Upd_Setup.exe">

--- a/index.php
+++ b/index.php
@@ -60,10 +60,9 @@ $all_modules = array_merge($rows['large1'], $rows['large2'], $rows['small']);
 </head>
 <body>
 <header>
-    <img src="RegiForraskod/kepek/suplogo.jpg" alt="SUP logo" class="logo">
-    <h1>SUP követés letöltések</h1>
 </header>
 <main>
+    <img src="RegiForraskod/kepek/suplogo.jpg" alt="SUP logo" class="hero-logo">
     <div class="grid">
         <?php foreach($all_modules as $code):
             if($code === 'SUP') {

--- a/style.css
+++ b/style.css
@@ -8,7 +8,7 @@
 body {
     margin: 0;
     font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-    background: linear-gradient(135deg, var(--bg-gradient-start), var(--bg-gradient-end));
+    background: linear-gradient(to bottom, var(--bg-gradient-start), var(--bg-gradient-end));
     color: var(--text-color);
     min-height: 100vh;
     display: flex;
@@ -16,11 +16,12 @@ body {
 }
 
 header {
-    background: linear-gradient(135deg, var(--bg-gradient-start), var(--bg-gradient-end));
+    background: linear-gradient(to bottom, var(--bg-gradient-start), var(--bg-gradient-end));
     color: #000;
     padding: 20px;
     display: flex;
     align-items: center;
+    justify-content: center;
 }
 
 header .logo {
@@ -31,6 +32,12 @@ header .logo {
 header h1 {
     margin: 0;
     font-size: 1.8em;
+}
+
+.hero-logo {
+    display: block;
+    height: 200px;
+    margin: 40px auto;
 }
 
 


### PR DESCRIPTION
## Summary
- remove text from header and add a large centered logo inside main
- orient background gradients vertically
- add hero-logo styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b599e8660832394bb11df24d20157