### PR TITLE
Add warning toast linking to A016 ISO

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,10 @@
 <main>
     <img src="kepek/suplogo.jpg" alt="SUP logo" class="hero-logo">
     <div class="grid">
+        <div class="alert-toast">
+            <p>Figyelem!!! A követéseket csak <a href="https://dl.sup.hu/dl/?file=supa016iso">A016</a>-s adatbázisverzióhoz telepítse fel!<br>
+            (Csak az adatbázis teljes mentése és a 2019. szeptember 4-i követés CD telepítése után!!!)</p>
+        </div>
         <h2 class="section-title">SUP® Rendszerrel kapcsolatos frissítések letöltése</h2>
         <div class="tile" style="--tile-color:#0078d7" data-name="SUP" data-version="16.11.9341.41126" data-date="2025.07.29. 11:27:46" data-size="N/A" data-file="SUP_Upd_Setup.exe" data-href="RegiForraskod/FileS/SUP_Upd_Setup.exe">
             <img src="kepek/sup.jpg" alt="SUP">

--- a/index.php
+++ b/index.php
@@ -64,6 +64,10 @@ $all_modules = array_merge($rows['large1'], $rows['large2'], $rows['small']);
 <main>
     <img src="kepek/suplogo.jpg" alt="SUP logo" class="hero-logo">
     <div class="grid">
+        <div class="alert-toast">
+            <p>Figyelem!!! A követéseket csak <a href="https://dl.sup.hu/dl/?file=supa016iso">A016</a>-s adatbázisverzióhoz telepítse fel!<br>
+            (Csak az adatbázis teljes mentése és a 2019. szeptember 4-i követés CD telepítése után!!!)</p>
+        </div>
         <?php foreach($all_modules as $code):
             if($code === 'SUP') {
         ?>

--- a/style.css
+++ b/style.css
@@ -67,6 +67,24 @@ main {
     color: var(--header-bg);
 }
 
+.alert-toast {
+    grid-column: 1 / -1;
+    background: #fff4ce;
+    border-left: 6px solid #ffb900;
+    border-radius: 4px;
+    padding: 15px;
+    margin-bottom: 20px;
+    font-size: 0.95em;
+    display: flex;
+    align-items: center;
+    min-height: 80px;
+}
+
+.alert-toast a {
+    color: var(--header-bg);
+    font-weight: 600;
+}
+
 .tile {
     background: #fff;
     border-radius: 10px;


### PR DESCRIPTION
## Summary
- add a yellow alert toast above the SUP update section
- link the `A016` text to the ISO download
- style the toast to match the existing design

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b62133cb08323ad2140da97e0020a