### PR TITLE
Add central module config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ File neve, Verzió, Feltöltés (kiadás) dátuma, Letöltési méret...
 - A weboldal nem használ cookie-kat, ezért ezzel kapcsolatos figyelmeztetés sem szükséges.
 
 Az aktuális verzió a csempés felületet modern, Windows 8/10 "Metro" stílusú megjelenéssel valósítja meg. A csempék színesek, lekerekítettek és reszponzívan rendeződnek rácsba.
+## Modul konfiguráció
+Az egyes csempék adatait a `modules.php` fájl tartalmazza. Ebben szerepel minden modul kódja, neve, rövid leírása, ikonjának fájlneve és a csempe színe. Az `index.php` ezt a fájlt tölti be, így a modulok adatai egy helyen karbantarthatók.

--- a/index.html
+++ b/index.html
@@ -1,108 +1,11 @@
 <!DOCTYPE html>
 <html lang="hu">
 <head>
-<meta charset="utf-8">
-<title>SUP követés letöltések</title>
-<link rel="stylesheet" href="style.css">
-<script src="script.js" defer></script>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0;url=index.php">
+    <title>SUP követés letöltések</title>
 </head>
 <body>
-<header>
-    <img src="kepek/suplogo.png" alt="SUP logo" class="logo">
-</header>
-<main>
-    <div class="grid">
-        <div class="alert-toast">
-            <p>Figyelem!!! A követéseket csak <a href="https://dl.sup.hu/dl/?file=supa016iso">A016</a>-s adatbázisverzióhoz telepítse fel!<br>
-            (Csak az adatbázis teljes mentése és a 2019. szeptember 4-i követés CD telepítése után!!!)</p>
-        </div>
-        <h2 class="section-title">SUP® Rendszerrel kapcsolatos frissítések letöltése</h2>
-        <div class="tile" style="--tile-color:#0078d7" data-name="SUP" data-version="16.11.9341.41126" data-date="2025.07.29. 11:27:46" data-size="N/A" data-file="SUP_Upd_Setup.exe" data-href="RegiForraskod/FileS/SUP_Upd_Setup.exe">
-            <img src="kepek/sup.jpg" alt="SUP">
-            <span class="name">SUP Pénzügyi és számviteli modul
-</span>
-            <span class="version">2025.07.29. 11:27:46</span>
-        </div>
-        <div class="tile" style="--tile-color:#1b6ac6" data-name="Raktár" data-version="16.11.9335.58734" data-date="2025.07.22. 16:20:54" data-size="N/A" data-file="RA_Upd_Setup.exe" data-href="RegiForraskod/FileS/RA_Upd_Setup.exe">
-            <img src="kepek/raktar.jpg" alt="Raktár">
-            <span class="name">SUP Raktári készlet és áruforgalmi modul
-</span>
-            <span class="version">2025.07.22. 16:20:54</span>
-        </div>
-        <div class="tile" style="--tile-color:#008272" data-name="Mérleg" data-version="16.11.9341.34614" data-date="2025.07.29. 09:38:26" data-size="N/A" data-file="LM_Upd_Setup.exe" data-href="RegiForraskod/FileS/LM_Upd_Setup.exe">
-            <img src="kepek/merleg.jpg" alt="Mérleg">
-            <span class="name">SUP Mérleg és elemzés modul
-</span>
-            <span class="version">2025.07.29. 09:38:26</span>
-        </div>
-        <div class="tile" style="--tile-color:#68217a" data-name="TIP" data-version="16.11.9335.38874" data-date="2025.07.23. 10:50:20" data-size="N/A" data-file="TIP_Upd_Setup.exe" data-href="RegiForraskod/FileS/TIP_Upd_Setup.exe">
-            <img src="kepek/tip.jpg" alt="TIP">
-            <span class="name">TIP Titkársági Programcsomag
-</span>
-            <span class="version">2025.07.23. 10:50:20</span>
-        </div>
-        <div class="tile" style="--tile-color:#00B050" data-name="SUP Xls.NET" data-version="16.10" data-date="2024.11.22. 10:50" data-size="N/A" data-file="SUP_XLS_NET_Setup.exe" data-href="RegiForraskod/FileS/SUP_XLS_NET_Setup.exe">
-            <img src="kepek/xls.jpg" alt="XLS">
-            <span class="name">SUP XLS.NET függvénycsomag
-</span>
-            <span class="version">2024.11.22. 10:50</span>
-        </div>
-        <div class="tile" style="--tile-color:#00cc6a" data-name="DbConnector" data-version="16.11.9327.60906" data-date="2025.07.14. 16:57:10" data-size="N/A" data-file="DBConnector_Setup.exe" data-href="RegiForraskod/FileS/DBConnector_Setup.exe">
-            <img src="kepek/dbconnector.jpg" alt="DbConnector">
-            <span class="name">DBConnector ütemezett feladatok
-</span>
-            <span class="version">2025.07.14. 16:57:10</span>
-        </div>
-        <div class="tile" style="--tile-color:#e81123" data-name="DbConnector API" data-version="3.1.9335" data-date="2025.02.18. 12:27" data-size="N/A" data-file="DbConnectorApi.jar" data-href="RegiForraskod/FileS/DbConnectorApi.jar">
-            <img src="kepek/dbconnectorapi.jpg" alt="DbConnector API">
-            <span class="name">DbConnector API</span>
-            <span class="version">2025.02.18. 12:27</span>
-        </div>
-        <div class="tile" style="--tile-color:#0099bc" data-name="QsFdbBackupService" data-version="2.1" data-date="2024.06.05. 09:00" data-size="N/A" data-file="QsBackupFdbService.zip" data-href="RegiForraskod/FileS/QsBackupFdbService.zip">
-            <img src="kepek/qsfdb.png" alt="QsFdbBackupService">
-            <span class="name">QsFdbBackUpService adatbázismentő
-</span>
-            <span class="version">2024.06.05. 09:00</span>
-        </div>
-        <h2 class="section-title">Kiegészítő szoftverek letöltése</h2>
-        <div class="tile" style="--tile-color:#da3b01" data-name="RustDesk" data-version="1.2.0" data-date="2023.02.20. 11:38" data-size="N/A" data-file="RustDeskQsoft.exe" data-href="RegiForraskod/FileS/RustDeskQsoft.exe">
-            <img src="kepek/tavman.jpg" alt="RustDesk">
-            <span class="name">Távmenedzselés (RustDesk)
-</span>
-            <span class="version">2023.02.20. 11:38</span>
-        </div>
-        <div class="tile" style="--tile-color:#ffb900" data-name="Firebird SQL" data-version="3.0.12" data-date="2024.12.18. 11:00" data-size="N/A" data-file="FB30_QSoft_Setup.exe" data-href="RegiForraskod/FileS/FB30_QSoft_Setup.exe">
-            <img src="kepek/firebird.jpg" alt="Firebird">
-            <span class="name">Firebird SQL adatbáziskezelő
-</span>
-            <span class="version">2024.12.18. 11:00</span>
-        </div>
-        <div class="tile" style="--tile-color:#2166b5" data-name="WebUpdate" data-version="16.6.8851.38885" data-date="2024.03.26. 11:50:14" data-size="N/A" data-file="WebUpdate.exe" data-href="RegiForraskod/FileS/WebUpdate.exe">
-            <img src="kepek/webupdate.jpg" alt="WebUpdate">
-            <span class="name">Internetes frissítés
-</span>
-            <span class="version">2024.03.26. 11:50:14</span>
-        </div>
-    </div>
-</main>
-<div id="modal" class="modal">
-    <div class="modal-content">
-        <span id="modal-close" class="close">&times;</span>
-        <h2 class="modal-title"></h2>
-        <ul class="modal-details">
-            <li>File: <span class="modal-file"></span></li>
-            <li>Verzió: <span class="modal-version"></span></li>
-            <li>A feltöltés dátuma: <span class="modal-date"></span></li>
-            <li>Méret: <span class="modal-size"></span></li>
-        </ul>
-        <div class="modal-buttons">
-            <a class="modal-download" href="#">Letöltés</a>
-        </div>
-    </div>
-</div>
-<footer>
-    <p>&copy; QSoft Kft. 1991-2025. Minden jog fenntartva.</p>
-    <p><a href="https://www.qsoft.hu/">Fő weboldal</a> | <a href="https://www.facebook.com/Qsoftkft">Facebook</a></p>
-</footer>
+    <p><a href="index.php">Tovább a letöltésekhez</a></p>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__.'/RegiForraskod/qsVersion.php';
+$config = require __DIR__.'/modules.php';
 
 function get_ver_info($code) {
     $fix_codes = array('XLS','FIREBIRD','QSBACKUPFDBSERVICE','RUSTDESK','DBCONNECTORAPI');
@@ -28,27 +29,11 @@ function module_files($code) {
         default: return '';
     }
 }
+$modules = $config["modules"];
+$rows = $config["rows"];
+$all_modules = array_merge($rows["large1"], $rows["large2"], $rows["small"]);
 
-$modules = [
-    'SUP' => ['name' => 'SUP', 'desc' => 'Pénzügyi és számviteli modul', 'icon' => 'sup.jpg', 'color' => '#0078d7'],
-    'RAKTAR' => ['name' => 'Raktár', 'desc' => 'Raktári készlet és áruforgalmi modul', 'icon' => 'raktar.jpg', 'color' => '#008272'],
-    'MERLEG' => ['name' => 'Mérleg', 'desc' => 'Mérleg és elemzés modul', 'icon' => 'merleg.jpg', 'color' => '#ff8c00'],
-    'TIP' => ['name' => 'TIP', 'desc' => 'Titkársági Programcsomag', 'icon' => 'tip.jpg', 'color' => '#68217a'],
-    'XLS' => ['name' => 'SUP Xls.NET', 'desc' => 'XLS.NET függvénycsomag', 'icon' => 'xls.jpg', 'color' => '#1b6ac6'],
-    'DBCONNECTOR' => ['name' => 'DbConnector', 'desc' => 'Ütemezett feladatok', 'icon' => 'dbconnector.jpg', 'color' => '#00cc6a'],
-    'DBCONNECTORAPI' => ['name' => 'DbConnector API', 'desc' => 'DbConnector API', 'icon' => 'dbconnectorapi.jpg', 'color' => '#e81123'],
-    'QSBACKUPFDBSERVICE' => ['name' => 'QsFdbBackupService', 'desc' => 'Adatbázismentő', 'icon' => 'qsfdb.png', 'color' => '#0099bc'],
-    'RUSTDESK' => ['name' => 'RustDesk', 'desc' => 'Távmenedzselés', 'icon' => 'tavman.jpg', 'color' => '#da3b01'],
-    'FIREBIRD' => ['name' => 'Firebird SQL', 'desc' => 'Firebird adatbáziskezelő', 'icon' => 'firebird.jpg', 'color' => '#ffb900'],
-    'WEBUPDATE' => ['name' => 'WebUpdate', 'desc' => 'Internetes frissítés', 'icon' => 'webupdate.jpg', 'color' => '#2166b5']
-];
 
-$rows = [
-    'large1' => ['SUP'],
-    'large2' => ['RAKTAR', 'MERLEG', 'TIP'],
-    'small'  => ['XLS', 'DBCONNECTOR', 'DBCONNECTORAPI', 'QSBACKUPFDBSERVICE', 'RUSTDESK', 'FIREBIRD', 'WEBUPDATE']
-];
-$all_modules = array_merge($rows['large1'], $rows['large2'], $rows['small']);
 ?>
 <!DOCTYPE html>
 <html lang="hu">

--- a/modules.php
+++ b/modules.php
@@ -1,0 +1,87 @@
+<?php
+return [
+    'modules' => [
+        'SUP' => [
+            'code' => 'SUP',
+            'name' => 'SUP',
+            'desc' => 'Pénzügyi és számviteli modul',
+            'icon' => 'sup.jpg',
+            'color' => '#0078d7'
+        ],
+        'RAKTAR' => [
+            'code' => 'RAKTAR',
+            'name' => 'Raktár',
+            'desc' => 'Raktári készlet és áruforgalmi modul',
+            'icon' => 'raktar.jpg',
+            'color' => '#008272'
+        ],
+        'MERLEG' => [
+            'code' => 'MERLEG',
+            'name' => 'Mérleg',
+            'desc' => 'Mérleg és elemzés modul',
+            'icon' => 'merleg.jpg',
+            'color' => '#ff8c00'
+        ],
+        'TIP' => [
+            'code' => 'TIP',
+            'name' => 'TIP',
+            'desc' => 'Titkársági Programcsomag',
+            'icon' => 'tip.jpg',
+            'color' => '#68217a'
+        ],
+        'XLS' => [
+            'code' => 'XLS',
+            'name' => 'SUP Xls.NET',
+            'desc' => 'XLS.NET függvénycsomag',
+            'icon' => 'xls.jpg',
+            'color' => '#1b6ac6'
+        ],
+        'DBCONNECTOR' => [
+            'code' => 'DBCONNECTOR',
+            'name' => 'DbConnector',
+            'desc' => 'Ütemezett feladatok',
+            'icon' => 'dbconnector.jpg',
+            'color' => '#00cc6a'
+        ],
+        'DBCONNECTORAPI' => [
+            'code' => 'DBCONNECTORAPI',
+            'name' => 'DbConnector API',
+            'desc' => 'DbConnector API',
+            'icon' => 'dbconnectorapi.jpg',
+            'color' => '#e81123'
+        ],
+        'QSBACKUPFDBSERVICE' => [
+            'code' => 'QSBACKUPFDBSERVICE',
+            'name' => 'QsFdbBackupService',
+            'desc' => 'Adatbázismentő',
+            'icon' => 'qsfdb.png',
+            'color' => '#0099bc'
+        ],
+        'RUSTDESK' => [
+            'code' => 'RUSTDESK',
+            'name' => 'RustDesk',
+            'desc' => 'Távmenedzselés',
+            'icon' => 'tavman.jpg',
+            'color' => '#da3b01'
+        ],
+        'FIREBIRD' => [
+            'code' => 'FIREBIRD',
+            'name' => 'Firebird SQL',
+            'desc' => 'Firebird adatbáziskezelő',
+            'icon' => 'firebird.jpg',
+            'color' => '#ffb900'
+        ],
+        'WEBUPDATE' => [
+            'code' => 'WEBUPDATE',
+            'name' => 'WebUpdate',
+            'desc' => 'Internetes frissítés',
+            'icon' => 'webupdate.jpg',
+            'color' => '#2166b5'
+        ]
+    ],
+    'rows' => [
+        'large1' => ['SUP'],
+        'large2' => ['RAKTAR', 'MERLEG', 'TIP'],
+        'small'  => ['XLS', 'DBCONNECTOR', 'DBCONNECTORAPI', 'QSBACKUPFDBSERVICE', 'RUSTDESK', 'FIREBIRD', 'WEBUPDATE']
+    ]
+];


### PR DESCRIPTION
## Summary
- create `modules.php` describing module tiles
- load the config from `index.php`
- redirect `index.html` to the PHP version to avoid duplicated data
- document the new data source in `README`

## Testing
- `php -l index.php`
- `php -l modules.php`

------
https://chatgpt.com/codex/tasks/task_e_688b7658c4c08323bef2ceec435fbf67