### PR TITLE
Implement toast message on download

### DIFF
--- a/script.js
+++ b/script.js
@@ -10,13 +10,40 @@ document.querySelectorAll('.tile').forEach(tile => {
         modal.classList.add('open');
     });
 });
+
 const modal = document.getElementById('modal');
-document.getElementById('modal-close').addEventListener('click', ()=>{
+const downloadBtn = modal.querySelector('.modal-download');
+const toastDuration = 5000;
+let toastContainer = document.getElementById('toast-container');
+
+if (!toastContainer) {
+    toastContainer = document.createElement('div');
+    toastContainer.id = 'toast-container';
+    document.body.appendChild(toastContainer);
+}
+
+function showToast(message) {
+    const toast = document.createElement('div');
+    toast.className = 'toast';
+    toast.textContent = message;
+    toastContainer.appendChild(toast);
+    setTimeout(() => {
+        toast.classList.add('hide');
+        toast.addEventListener('animationend', () => toast.remove());
+    }, toastDuration);
+}
+
+downloadBtn.addEventListener('click', () => {
+    modal.classList.remove('open');
+    showToast('Letöltés alatt.');
+});
+
+document.getElementById('modal-close').addEventListener('click', () => {
     modal.classList.remove('open');
 });
 modal.addEventListener('click', e => {
-    if(e.target === modal) modal.classList.remove('open');
+    if (e.target === modal) modal.classList.remove('open');
 });
 document.addEventListener('keydown', e => {
-    if(e.key === 'Escape') modal.classList.remove('open');
+    if (e.key === 'Escape') modal.classList.remove('open');
 });

--- a/style.css
+++ b/style.css
@@ -254,3 +254,45 @@ footer a {
         margin-bottom: 10px;
     }
 }
+
+#toast-container {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    z-index: 1200;
+}
+
+.toast {
+    background: #dff6dd;
+    border-left: 4px solid #107c10;
+    color: #107c10;
+    padding: 10px 16px;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    animation: fadeInToast 0.3s forwards;
+}
+
+.toast.hide {
+    animation: fadeOutToast 0.3s forwards;
+}
+
+@keyframes fadeInToast {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes fadeOutToast {
+    to {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+}


### PR DESCRIPTION
## Summary
- add toast UI element in CSS
- implement toast logic in script.js so that clicking modal download closes the modal and shows a toast

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688bbd84fd348323a112fe73d7479e55