### PR TITLE
Add extra download tile

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,10 @@
 </span>
             <span class="version">2024.03.26. 11:50:14</span>
         </div>
+        <a class="tile external" style="--tile-color:#2564cf" href="https://aral.qsoft.hu/d/d11f48cbc61548619ad0/" target="_blank">
+            <img src="kepek/Blue32x32.png" alt="További letöltések">
+            <span class="name">További letöltések</span>
+        </a>
     </div>
 </main>
 <div id="modal" class="modal">

--- a/index.php
+++ b/index.php
@@ -86,6 +86,10 @@ $all_modules = array_merge($rows['large1'], $rows['large2'], $rows['small']);
             <span class="version"><?php echo $d; ?></span>
         </div>
         <?php endforeach; ?>
+        <a class="tile external" style="--tile-color:#2564cf" href="https://aral.qsoft.hu/d/d11f48cbc61548619ad0/" target="_blank">
+            <img src="kepek/Blue32x32.png" alt="További letöltések">
+            <span class="name">További letöltések</span>
+        </a>
     </div>
 </main>
 <div id="modal" class="modal">

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-document.querySelectorAll('.tile').forEach(tile => {
+document.querySelectorAll('.tile:not(.external)').forEach(tile => {
     tile.addEventListener('click', () => {
         const modal = document.getElementById('modal');
         modal.querySelector('.modal-title').textContent = tile.querySelector('.name').textContent.trim();

--- a/style.css
+++ b/style.css
@@ -98,6 +98,7 @@ main {
     border-left: 6px solid var(--tile-color, #2564cf);
     color: var(--text-color);
     cursor: pointer;
+    text-decoration: none;
 }
 
 .tile:hover {


### PR DESCRIPTION
## Summary
- add a missing external link card to the "Kiegészítő szoftverek" section
- avoid opening a modal for external tiles
- allow tiles to be anchors without underline

## Testing
- `php -l index.php`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_688d04ac6604832397f7a739a8e29ba1