### PR TITLE
Move alert toast to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,12 +10,12 @@
 <body>
 <header>
     <img src="kepek/suplogo.png" alt="SUP logo" class="logo">
+    <div class="alert-toast">
+        <p>Figyelem!!! A követéseket csak <a href="https://dl.sup.hu/dl/?file=supa016iso">A016</a>-s adatbázisverzióhoz telepítse fel! (Csak az adatbázis teljes mentése és a 2019. szeptember 4-i követés CD telepítése után!!!)</p>
+    </div>
 </header>
 <main>
     <div class="grid">
-        <div class="alert-toast">
-            <p>Figyelem!!! A követéseket csak <a href="https://dl.sup.hu/dl/?file=supa016iso">A016</a>-s adatbázisverzióhoz telepítse fel! (Csak az adatbázis teljes mentése és a 2019. szeptember 4-i követés CD telepítése után!!!)</p>
-        </div>
         <h2 class="section-title">SUP® Rendszerrel kapcsolatos frissítések letöltése</h2>
         <div class="tile" style="--tile-color:#0078d7" data-name="SUP" data-version="16.11.9341.41126" data-date="2025.07.29. 11:27:46" data-size="N/A" data-file="SUP_Upd_Setup.exe" data-href="FileS/SUP_Upd_Setup.exe">
             <img src="kepek/sup.jpg" alt="SUP">

--- a/index.php
+++ b/index.php
@@ -62,13 +62,13 @@ $all_modules = array_merge($rows['large1'], $rows['large2'], $rows['small']);
 <body>
 <header>
     <img src="kepek/suplogo.png" alt="SUP logo" class="logo">
+    <div class="alert-toast">
+        <p>Figyelem!!! A követéseket csak <a href="https://dl.sup.hu/dl/?file=supa016iso">A016</a>-s adatbázisverzióhoz telepítse fel!<br>
+        (Csak az adatbázis teljes mentése és a 2019. szeptember 4-i követés CD telepítése után!!!)</p>
+    </div>
 </header>
 <main>
     <div class="grid">
-        <div class="alert-toast">
-            <p>Figyelem!!! A követéseket csak <a href="https://dl.sup.hu/dl/?file=supa016iso">A016</a>-s adatbázisverzióhoz telepítse fel!<br>
-            (Csak az adatbázis teljes mentése és a 2019. szeptember 4-i követés CD telepítése után!!!)</p>
-        </div>
         <?php foreach($all_modules as $code):
             if($code === 'SUP') {
         ?>

--- a/style.css
+++ b/style.css
@@ -21,7 +21,8 @@ header {
     padding: 25px 20px 5px 20px;
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-start;
+    gap: 20px;
 }
 
 header .logo {
@@ -64,17 +65,17 @@ main {
 }
 
 .alert-toast {
-    grid-column: 1 / -1;
     background: #fff4ce;
     border-left: 6px solid #ffb900;
     border-radius: 4px;
     padding: 0 15px;
-    margin-bottom: 0;
     font-size: 0.95em;
     font-weight: bold;
     display: flex;
     align-items: center;
-    min-height: 80px;
+    min-height: 60px;
+    flex: 1;
+    margin-left: 20px;
 }
 
 .alert-toast a {
@@ -252,6 +253,10 @@ footer a {
     }
     header .logo {
         margin-bottom: 10px;
+    }
+    header .alert-toast {
+        margin-left: 0;
+        width: 100%;
     }
 }
 


### PR DESCRIPTION
## Summary
- move alert toast message from grid into the page header
- adjust layout styles so the toast appears next to the logo
- keep layout usable on small screens

## Testing
- `php -l index.php`

------
https://chatgpt.com/codex/tasks/task_e_688d15c904948323a7dab06431e89311