### PR TITLE
Hide share tile visually

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
 </span>
             <span class="version">2024.03.26. 11:50:14</span>
         </div>
-        <a class="tile external" style="--tile-color:#2564cf" href="https://aral.qsoft.hu/d/d11f48cbc61548619ad0/" target="_blank">
+        <a class="tile external invisible" style="--tile-color:#2564cf" href="https://aral.qsoft.hu/d/d11f48cbc61548619ad0/" target="_blank">
             <img src="kepek/Blue32x32.png" alt="Fájl vagy könyvtár megosztás">
             <span class="name">Fájl vagy könyvtár megosztás</span>
         </a>

--- a/style.css
+++ b/style.css
@@ -101,6 +101,10 @@ main {
     text-decoration: none;
 }
 
+.tile.invisible {
+    opacity: 0;
+}
+
 .tile:hover {
     transform: translateY(-4px);
     box-shadow: 0 4px 12px rgba(0,0,0,0.2);


### PR DESCRIPTION
## Summary
- hide the "Fájl vagy könyvtár megosztás" tile but keep it clickable
- add CSS helper class for invisible tiles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d1a35a8ac83239e44c829ecaa1852