### PR TITLE
Add unique URL hashes for module modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,67 +17,67 @@
 <main>
     <div class="grid">
         <h2 class="section-title">SUP® Rendszerrel kapcsolatos frissítések letöltése</h2>
-        <div class="tile" style="--tile-color:#0078d7" data-name="SUP" data-version="16.11.9341.41126" data-date="2025.07.29. 11:27:46" data-size="N/A" data-file="SUP_Upd_Setup.exe" data-href="FileS/SUP_Upd_Setup.exe">
+        <div class="tile" style="--tile-color:#0078d7" data-code="SUP" data-name="SUP" data-version="16.11.9341.41126" data-date="2025.07.29. 11:27:46" data-size="N/A" data-file="SUP_Upd_Setup.exe" data-href="FileS/SUP_Upd_Setup.exe">
             <img src="kepek/sup.jpg" alt="SUP">
             <span class="name">SUP Pénzügyi és számviteli modul
 </span>
             <span class="version">2025.07.29. 11:27:46</span>
         </div>
-        <div class="tile" style="--tile-color:#1b6ac6" data-name="Raktár" data-version="16.11.9335.58734" data-date="2025.07.22. 16:20:54" data-size="N/A" data-file="RA_Upd_Setup.exe" data-href="FileS/RA_Upd_Setup.exe">
+        <div class="tile" style="--tile-color:#1b6ac6" data-code="RAKTAR" data-name="Raktár" data-version="16.11.9335.58734" data-date="2025.07.22. 16:20:54" data-size="N/A" data-file="RA_Upd_Setup.exe" data-href="FileS/RA_Upd_Setup.exe">
             <img src="kepek/raktar.jpg" alt="Raktár">
             <span class="name">SUP Raktári készlet és áruforgalmi modul
 </span>
             <span class="version">2025.07.22. 16:20:54</span>
         </div>
-        <div class="tile" style="--tile-color:#1DA1F2" data-name="Mérleg" data-version="16.11.9341.34614" data-date="2025.07.29. 09:38:26" data-size="N/A" data-file="LM_Upd_Setup.exe" data-href="FileS/LM_Upd_Setup.exe">
+        <div class="tile" style="--tile-color:#1DA1F2" data-code="MERLEG" data-name="Mérleg" data-version="16.11.9341.34614" data-date="2025.07.29. 09:38:26" data-size="N/A" data-file="LM_Upd_Setup.exe" data-href="FileS/LM_Upd_Setup.exe">
             <img src="kepek/merleg.jpg" alt="Mérleg">
             <span class="name">SUP Mérleg és elemzés modul
 </span>
             <span class="version">2025.07.29. 09:38:26</span>
         </div>
-        <div class="tile" style="--tile-color:#68217a" data-name="TIP" data-version="16.11.9335.38874" data-date="2025.07.23. 10:50:20" data-size="N/A" data-file="TIP_Upd_Setup.exe" data-href="FileS/TIP_Upd_Setup.exe">
+        <div class="tile" style="--tile-color:#68217a" data-code="TIP" data-name="TIP" data-version="16.11.9335.38874" data-date="2025.07.23. 10:50:20" data-size="N/A" data-file="TIP_Upd_Setup.exe" data-href="FileS/TIP_Upd_Setup.exe">
             <img src="kepek/tip.jpg" alt="TIP">
             <span class="name">TIP Titkársági Programcsomag
 </span>
             <span class="version">2025.07.23. 10:50:20</span>
         </div>
-        <div class="tile" style="--tile-color:#00B050" data-name="SUP Xls.NET" data-version="16.10" data-date="2024.11.22. 10:50" data-size="N/A" data-file="SUP_XLS_NET_Setup.exe" data-href="FileS/SUP_XLS_NET_Setup.exe">
+        <div class="tile" style="--tile-color:#00B050" data-code="XLS" data-name="SUP Xls.NET" data-version="16.10" data-date="2024.11.22. 10:50" data-size="N/A" data-file="SUP_XLS_NET_Setup.exe" data-href="FileS/SUP_XLS_NET_Setup.exe">
             <img src="kepek/xls.jpg" alt="XLS">
             <span class="name">SUP XLS.NET függvénycsomag
 </span>
             <span class="version">2024.11.22. 10:50</span>
         </div>
-        <div class="tile" style="--tile-color:#00cc6a" data-name="DbConnector" data-version="16.11.9327.60906" data-date="2025.07.14. 16:57:10" data-size="N/A" data-file="DBConnector_Setup.exe" data-href="FileS/DBConnector_Setup.exe">
+        <div class="tile" style="--tile-color:#00cc6a" data-code="DBCONNECTOR" data-name="DbConnector" data-version="16.11.9327.60906" data-date="2025.07.14. 16:57:10" data-size="N/A" data-file="DBConnector_Setup.exe" data-href="FileS/DBConnector_Setup.exe">
             <img src="kepek/dbconnector.jpg" alt="DbConnector">
             <span class="name">DBConnector ütemezett feladatok
 </span>
             <span class="version">2025.07.14. 16:57:10</span>
         </div>
-        <div class="tile" style="--tile-color:#e81123" data-name="DbConnector API" data-version="3.1.9335" data-date="2025.02.18. 12:27" data-size="N/A" data-file="DbConnectorApi.jar" data-href="FileS/DbConnectorApi.jar">
+        <div class="tile" style="--tile-color:#e81123" data-code="DBCONNECTORAPI" data-name="DbConnector API" data-version="3.1.9335" data-date="2025.02.18. 12:27" data-size="N/A" data-file="DbConnectorApi.jar" data-href="FileS/DbConnectorApi.jar">
             <img src="kepek/dbconnectorapi.jpg" alt="DbConnector API">
             <span class="name">DbConnector API</span>
             <span class="version">2025.02.18. 12:27</span>
         </div>
-        <div class="tile" style="--tile-color:#0099bc" data-name="QsFdbBackupService" data-version="2.1" data-date="2024.06.05. 09:00" data-size="N/A" data-file="QsBackupFdbService.zip" data-href="FileS/QsBackupFdbService.zip">
+        <div class="tile" style="--tile-color:#0099bc" data-code="QSBACKUPFDBSERVICE" data-name="QsFdbBackupService" data-version="2.1" data-date="2024.06.05. 09:00" data-size="N/A" data-file="QsBackupFdbService.zip" data-href="FileS/QsBackupFdbService.zip">
             <img src="kepek/qsfdb.png" alt="QsFdbBackupService">
             <span class="name">QsFdbBackUpService adatbázismentő
 </span>
             <span class="version">2024.06.05. 09:00</span>
         </div>
         <h2 class="section-title">Kiegészítő szoftverek letöltése</h2>
-        <div class="tile" style="--tile-color:#da3b01" data-name="RustDesk" data-version="1.2.0" data-date="2023.02.20. 11:38" data-size="N/A" data-file="RustDeskQsoft.exe" data-href="FileS/RustDeskQsoft.exe">
+        <div class="tile" style="--tile-color:#da3b01" data-code="RUSTDESK" data-name="RustDesk" data-version="1.2.0" data-date="2023.02.20. 11:38" data-size="N/A" data-file="RustDeskQsoft.exe" data-href="FileS/RustDeskQsoft.exe">
             <img src="kepek/tavman.jpg" alt="RustDesk">
             <span class="name">Távmenedzselés (RustDesk)
 </span>
             <span class="version">2023.02.20. 11:38</span>
         </div>
-        <div class="tile" style="--tile-color:#ffb900" data-name="Firebird SQL" data-version="3.0.12" data-date="2024.12.18. 11:00" data-size="N/A" data-file="FB30_QSoft_Setup.exe" data-href="FileS/FB30_QSoft_Setup.exe">
+        <div class="tile" style="--tile-color:#ffb900" data-code="FIREBIRD" data-name="Firebird SQL" data-version="3.0.12" data-date="2024.12.18. 11:00" data-size="N/A" data-file="FB30_QSoft_Setup.exe" data-href="FileS/FB30_QSoft_Setup.exe">
             <img src="kepek/firebird.jpg" alt="Firebird">
             <span class="name">Firebird SQL adatbáziskezelő
 </span>
             <span class="version">2024.12.18. 11:00</span>
         </div>
-        <div class="tile" style="--tile-color:#2166b5" data-name="WebUpdate" data-version="16.6.8851.38885" data-date="2024.03.26. 11:50:14" data-size="N/A" data-file="WebUpdate.exe" data-href="FileS/WebUpdate.exe">
+        <div class="tile" style="--tile-color:#2166b5" data-code="WEBUPDATE" data-name="WebUpdate" data-version="16.6.8851.38885" data-date="2024.03.26. 11:50:14" data-size="N/A" data-file="WebUpdate.exe" data-href="FileS/WebUpdate.exe">
             <img src="kepek/webupdate.jpg" alt="WebUpdate">
             <span class="name">Internetes frissítés
 </span>

--- a/index.php
+++ b/index.php
@@ -80,7 +80,7 @@ $all_modules = array_merge($rows['large1'], $rows['large2'], $rows['small']);
             list($v,$d,$s) = get_ver_info($code);
             $file = module_files($code);
         ?>
-        <div class="tile" style="--tile-color:<?php echo $info['color']; ?>" data-name="<?php echo $info['name']; ?>" data-version="<?php echo $v; ?>" data-date="<?php echo $d; ?>" data-size="<?php echo $s; ?>" data-file="<?php echo $file; ?>" data-href="FileS/<?php echo $file; ?>">
+        <div class="tile" style="--tile-color:<?php echo $info['color']; ?>" data-code="<?php echo $code; ?>" data-name="<?php echo $info['name']; ?>" data-version="<?php echo $v; ?>" data-date="<?php echo $d; ?>" data-size="<?php echo $s; ?>" data-file="<?php echo $file; ?>" data-href="FileS/<?php echo $file; ?>">
             <img src="kepek/<?php echo $info['icon']; ?>" alt="<?php echo $info['name']; ?>">
             <span class="name"><?php echo $info['name']; ?></span>
             <span class="version"><?php echo $d; ?></span>

--- a/script.js
+++ b/script.js
@@ -1,17 +1,29 @@
-document.querySelectorAll('.tile:not(.external)').forEach(tile => {
-    tile.addEventListener('click', () => {
-        const modal = document.getElementById('modal');
-        modal.querySelector('.modal-title').textContent = tile.querySelector('.name').textContent.trim();
-        modal.querySelector('.modal-file').textContent = tile.dataset.file;
-        modal.querySelector('.modal-version').textContent = tile.dataset.version;
-        modal.querySelector('.modal-date').textContent = tile.dataset.date;
-        modal.querySelector('.modal-size').textContent = tile.dataset.size;
-        modal.querySelector('.modal-download').href = tile.dataset.href;
-        modal.classList.add('open');
-    });
-});
-
 const modal = document.getElementById('modal');
+let currentCode = null;
+
+function openModal(tile) {
+    modal.querySelector('.modal-title').textContent = tile.querySelector('.name').textContent.trim();
+    modal.querySelector('.modal-file').textContent = tile.dataset.file;
+    modal.querySelector('.modal-version').textContent = tile.dataset.version;
+    modal.querySelector('.modal-date').textContent = tile.dataset.date;
+    modal.querySelector('.modal-size').textContent = tile.dataset.size;
+    modal.querySelector('.modal-download').href = tile.dataset.href;
+    modal.classList.add('open');
+    currentCode = tile.dataset.code;
+    if (currentCode) {
+        history.replaceState(null, '', '#' + currentCode);
+    }
+}
+
+function closeModal() {
+    modal.classList.remove('open');
+    currentCode = null;
+    history.replaceState(null, '', location.pathname);
+}
+
+document.querySelectorAll('.tile:not(.external)').forEach(tile => {
+    tile.addEventListener('click', () => openModal(tile));
+});
 const downloadBtn = modal.querySelector('.modal-download');
 const toastDuration = 5000;
 let toastContainer = document.getElementById('toast-container');
@@ -34,16 +46,29 @@ function showToast(message) {
 }
 
 downloadBtn.addEventListener('click', () => {
-    modal.classList.remove('open');
+    closeModal();
     showToast('Letöltés alatt.');
 });
 
-document.getElementById('modal-close').addEventListener('click', () => {
-    modal.classList.remove('open');
-});
+document.getElementById('modal-close').addEventListener('click', closeModal);
 modal.addEventListener('click', e => {
-    if (e.target === modal) modal.classList.remove('open');
+    if (e.target === modal) closeModal();
 });
 document.addEventListener('keydown', e => {
-    if (e.key === 'Escape') modal.classList.remove('open');
+    if (e.key === 'Escape') closeModal();
 });
+
+function handleHash() {
+    const code = location.hash.replace('#', '');
+    if (code) {
+        const tile = document.querySelector('.tile[data-code="' + code + '"]');
+        if (tile) {
+            openModal(tile);
+        }
+    } else if (modal.classList.contains('open')) {
+        closeModal();
+    }
+}
+
+window.addEventListener('hashchange', handleHash);
+window.addEventListener('DOMContentLoaded', handleHash);


### PR DESCRIPTION
## Summary
- add `data-code` attributes to tiles
- update PHP generator to include `data-code`
- enhance `script.js` so modals update the URL hash and open based on it

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d1df62acc8323a8a62943ccd2a9c6